### PR TITLE
Handle API errors when checking appointment access

### DIFF
--- a/src/hooks/useAppointmentAccess.ts
+++ b/src/hooks/useAppointmentAccess.ts
@@ -59,15 +59,12 @@ export const useAppointmentAccess = (): UseAppointmentAccessReturn => {
         cache: 'no-store'
       });
 
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
       const data: AppointmentAccessResponse = await response.json();
-      
-      console.log('Appointment access response:', data);
-      
-      if (data.success) {
+
+      if (!response.ok) {
+        setAccessStatus(data.data);
+        setError(data.message);
+      } else if (data.success) {
         setAccessStatus(data.data);
         lastCheckRef.current = Date.now();
       } else {
@@ -104,12 +101,13 @@ export const useAppointmentAccess = (): UseAppointmentAccessReturn => {
         cache: 'no-store'
       });
 
+      const data: AppointmentAccessResponse = await response.json();
+
       if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+        setError(data.message);
+        return false;
       }
 
-      const data = await response.json();
-      
       if (data.success) {
         // Refresh access status after granting
         await checkAccess();


### PR DESCRIPTION
## Summary
- improve appointment access fetch handlers to parse JSON and avoid throwing on non-200 responses
- set error message from server so UI can show it

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842c010ccf483219c5964b4c67cd63c